### PR TITLE
Update owners to add Heba and remove Brian Goff

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,8 +1,6 @@
 ### Core Maintainers
 
-Ria Bhatia (ribhatia@microsoft.com)
-
-Brian Goff (brian.goff@microsoft.com)
+Heba Elayoty (heba.elayoty@microsoft.com)
 
 Paulo Pires (pjpires@gmail.com)
 
@@ -14,8 +12,7 @@ Sargun Dhillon (sargun@netflix.com) - Elected October, 2019
 
 **Azure**
 
-Ernest Wong (Chun.Wong@microsoft.com)
-Ibrahim Aboulfetouh (ibabou@microsoft.com)
+Heba Elayoty (heba.elayoty@microsoft.com)
 
 **AWS Fargate**
 


### PR DESCRIPTION
I (Brian) am not really able to dedicate time to the project and Heba has stepped up to represent Microsoft here. Ria, Earnest, and Ibrahim are no longer at Microsoft and are also no longer involved with the project.

Heba has been helping organize and maintain both the core VK project as well as azure-aci.